### PR TITLE
Portfolio Improvements & Engagement Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ components/
   Navbar.jsx          # Fixed navbar with mobile hamburger menu
   SocialLinks.jsx     # Vertical social icon strip
   Skill.jsx           # Inline skill highlight chip
-  SmoothLink.jsx      # Anchor wrapper with smooth-scroll behaviour
 data.json             # Content data — experience entries, about text, email
 public/assets/        # Static icons and images
 styles/globals.css    # Global styles and Tailwind component layer

--- a/README.md
+++ b/README.md
@@ -1,9 +1,138 @@
-# Portfolio Website
+# Shivam Verma — Portfolio
 
-## Technologies used
-- Next.js
-- Tailwindcss
-- GraphQL
+Personal portfolio website built with Next.js, showcasing my experience, projects, and contact information.
 
+**Live site:** [stoppieboy-github-io.vercel.app](https://stoppieboy-github-io.vercel.app/)
 
-Visit my Site: [Shivam's Portfolio](https://stoppieboy-github-io.vercel.app/)
+---
+
+## Tech Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | [Next.js 14](https://nextjs.org/) (App Router) |
+| Styling | [Tailwind CSS](https://tailwindcss.com/) |
+| Data fetching | [Apollo Client](https://www.apollographql.com/docs/react/) + GitHub GraphQL API |
+| KV store | [Vercel KV](https://vercel.com/docs/storage/vercel-kv) |
+| Font | [Urbanist](https://fonts.google.com/specimen/Urbanist) via `next/font/google` |
+| Deployment | [Vercel](https://vercel.com/) |
+
+---
+
+## Features
+
+- **Hero** — Introduction with animated scroll cue and social links (GitHub, LinkedIn, HackerRank)
+- **About** — Bio and skill highlights
+- **Experience** — Work history driven by `data.json` — no code change needed to add a new role
+- **Projects** — Live-fetched pinned GitHub repositories via the GitHub GraphQL API, with skeleton loading and error states
+- **Contact** — Direct mailto link
+- **Navbar** — Frosted-glass nav with smooth scroll; collapses to a hamburger menu on mobile
+
+---
+
+## Project Structure
+
+```
+app/
+  layout.jsx          # Root layout, metadata (OG + Twitter cards), Navbar
+  page.jsx            # Page composition — assembles all sections
+  api/get-repos/      # API route — fetches pinned GitHub repos via GraphQL
+components/
+  Home.jsx            # Hero section
+  About.jsx           # About section
+  Experience.jsx      # Experience section
+  Projects.jsx        # Projects section (client component)
+  Contact.jsx         # Contact section
+  Navbar.jsx          # Fixed navbar with mobile hamburger menu
+  SocialLinks.jsx     # Vertical social icon strip
+  Skill.jsx           # Inline skill highlight chip
+  SmoothLink.jsx      # Anchor wrapper with smooth-scroll behaviour
+data.json             # Content data — experience entries, about text, email
+public/assets/        # Static icons and images
+styles/globals.css    # Global styles and Tailwind component layer
+```
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 18+
+- A GitHub personal access token with `read:user` scope (for the GraphQL API)
+- A Vercel KV store (for `about_text` and `email` in production)
+
+### Local development
+
+1. Clone the repo:
+   ```bash
+   git clone https://github.com/stoppieboy/stoppieboy.github.io.git
+   cd stoppieboy.github.io
+   ```
+
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+3. Create a `.env.local` file:
+   ```env
+   GITHUB_ACCESS_TOKEN=your_github_token_here
+   KV_REST_API_URL=your_vercel_kv_url
+   KV_REST_API_TOKEN=your_vercel_kv_token
+   ```
+
+4. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+   Open [http://localhost:3000](http://localhost:3000).
+
+### Build for production
+
+```bash
+npm run build
+npm start
+```
+
+### Lint
+
+```bash
+npm run lint
+```
+
+### Tests
+
+```bash
+npm test
+```
+
+---
+
+## Content Updates
+
+All site content is driven by [`data.json`](data.json) — no component code changes needed for routine updates:
+
+```jsonc
+{
+  "email": "you@example.com",
+  "about_text": "...",
+  "experience": [
+    {
+      "title": "Job Title",
+      "company": "Company Name",
+      "duration": "Month Year – Month Year",
+      "description": ["Bullet one.", "Bullet two."]
+    }
+  ]
+}
+```
+
+Pinned GitHub projects are fetched live from the GitHub API — pin/unpin repos on GitHub and they update automatically.
+
+---
+
+## Deployment
+
+The site is deployed on Vercel. Push to `main` to trigger a production deploy. Environment variables (`GITHUB_ACCESS_TOKEN`, `KV_REST_API_URL`, `KV_REST_API_TOKEN`) must be set in the Vercel project settings.

--- a/Utility/smoothScroll.js
+++ b/Utility/smoothScroll.js
@@ -1,9 +1,0 @@
-const smoothScroll = (e) => {
-    e.preventDefault();
-    const id = e.target.getAttribute('href').slice(1)
-    if(document.getElementById(id)){
-        document.getElementById(id).scrollIntoView({behavior: 'smooth'});
-    }
-}
-
-export default smoothScroll;

--- a/app/api/get-repos/route.js
+++ b/app/api/get-repos/route.js
@@ -19,6 +19,8 @@ export const GET = async(req, {params}) => {
                                     name
                                     url
                                     description
+                                    homepageUrl
+                                    stargazerCount
                                     primaryLanguage{
                                         name,
                                         color

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -26,7 +26,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="en">
       <body className={font.className} >
-        <main className="flex flex-col items-center text-secondary2 bg-accent2">
+        <main className="flex flex-col items-center text-secondary2 bg-accent2 select-none">
           <Navbar/>
           {/* <main id="main" className="min-h-screen w-full px-4 bg-[url('/assets/images/portfolio_bg.png')] bg-no-repeat bg-contain"> */}
           <main id="main" className="min-h-screen w-full px-4" aria-label="Main content">

--- a/app/layout.jsx
+++ b/app/layout.jsx
@@ -1,20 +1,25 @@
 import Navbar from '@/components/Navbar'
 
 import '../styles/globals.css'
-// import { Inter } from 'next/font/google'
-import { Urbanist, Poppins, DM_Sans, Roboto, Jost, PT_Mono } from 'next/font/google'
+import { Urbanist } from 'next/font/google'
 
-// const inter = Inter({ subsets: ['latin'] })
 const font = Urbanist({ subsets: ['latin'], preload: true, weight: ['100', '200', '300','400', '500','600', '700', '800', '900'] })
-// const font = Roboto({ subsets: ['latin'], preload: true, weight: ['100', '300', '400', '500', '700', '900'] })
-// const font = Poppins({ subsets: ['latin'], preload: true, weight: ['100', '200', '300','400', '500','600', '700', '800', '900'] })
-// const font = DM_Sans({ subsets: ['latin'], preload: true, weight: ['100', '200', '300','400', '500','600', '700', '800', '900'] })
-// const font = Jost({ subsets: ['latin'], preload: true, weight: ['100', '200', '300','400', '500','600', '700', '800', '900'] })
-// const font = PT_Mono({ subsets: ['latin'], preload: true, weight: ['400'] })
 
 export const metadata = {
   title: "Shivam Verma | Software Developer",
-  description: 'A portfolio website developed and maintained by Shivam Verma',
+  description: 'Software Engineer with 1+ year of experience in full-stack development and API design.',
+  openGraph: {
+    title: "Shivam Verma | Software Developer",
+    description: "Software Engineer with 1+ year of experience in full-stack development and API design.",
+    url: "https://stoppieboy.github.io",
+    siteName: "Shivam Verma Portfolio",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: "Shivam Verma | Software Developer",
+    description: "Software Engineer with 1+ year of experience in full-stack development and API design.",
+  },
 }
 
 export default function RootLayout({ children }) {
@@ -24,7 +29,7 @@ export default function RootLayout({ children }) {
         <main className="flex flex-col items-center text-secondary2 bg-accent2">
           <Navbar/>
           {/* <main id="main" className="min-h-screen w-full px-4 bg-[url('/assets/images/portfolio_bg.png')] bg-no-repeat bg-contain"> */}
-          <main id="main" className="min-h-screen w-full px-4">
+          <main id="main" className="min-h-screen w-full px-4" aria-label="Main content">
             {children}
           </main>
         </main>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -27,7 +27,7 @@ export default async function Home() {
       <HomePage id="home"/>
 
       {/* About */}
-      <About id="about" data={data}/>
+      <About id="about"/>
 
       {/* Experience */}
       <Experience id="experience"/>

--- a/components/About.jsx
+++ b/components/About.jsx
@@ -1,19 +1,13 @@
 import Image from "next/image"
-import profilepic from "../public/assets/images/user_img_bw.jpg"
 import Skill from "./Skill"
 
 const About = ({ id, data }) => {
     return (
-        <div id={id || "about"} className='h-[100vh] flex flex-col sm:flex-row items-center max-sm:space-y-10 sm:space-x-5 md:space-x-10 lg:space-x-24 xl:space-x-16 [ md:px-12 lg:px-24 xl:px-36 ] [ max-[450px]:text-xl text-2xl sm:text-3xl lg:text-3xl ]'>
+        <div id={id || "about"} className='min-h-[100vh] flex flex-col sm:flex-row items-center max-sm:space-y-10 sm:space-x-5 md:space-x-10 lg:space-x-24 xl:space-x-16 [ md:px-12 lg:px-24 xl:px-36 ] [ max-[450px]:text-xl text-2xl sm:text-3xl lg:text-3xl ]'>
 
             <Image src="/assets/images/user_img_bw.jpg" width={250} height={0} alt="Shivam's Picture" className='rounded-3xl'/>
-            {/* <Image src={profilepic} alt="Shivam's Picture" width={250} className='rounded-3xl'/> */}
 
-            {/* <div className='flex-grow'> 
-                <p className=' px-5 sm:font-medium text-center sm:text-start'>{data.about_text}</p>
-            </div> */}
             <div className='flex-grow'> 
-                {/* <p className=' px-5 sm:font-medium text-center sm:text-start leading-[1.7] '>A <Skill>Software engineering fresher</Skill>, experienced in both front-end and back-end technologies, eager to contribute to dynamic and innovative web projects. Proficient in HTML, CSS, JavaScript, and frameworks like <Skill>React</Skill> and <Skill>Node.js</Skill>, as well as databases such as <Skill>MySQL</Skill> and <Skill>MongoDB</Skill>, I am passionate about building responsive, user-friendly applications and continuously improving my technical skills.</p> */}
                 <p className=' px-5 sm:font-medium text-center sm:text-start leading-[1.7] '><Skill>Software Engineer</Skill> with 1+ year of experience in full-stack development and API design. Passionate about solving complex problems and building technology that delivers measurable value. Expertise in Java, JavaScript, Golang and frameworks like <Skill>React.js</Skill> and <Skill>Next.js</Skill>.</p>
             </div>
 

--- a/components/About.jsx
+++ b/components/About.jsx
@@ -1,14 +1,31 @@
 import Image from "next/image"
 import Skill from "./Skill"
+import data from "../data.json"
 
-const About = ({ id, data }) => {
+const About = ({ id }) => {
     return (
-        <div id={id || "about"} className='min-h-[100vh] flex flex-col sm:flex-row items-center max-sm:space-y-10 sm:space-x-5 md:space-x-10 lg:space-x-24 xl:space-x-16 [ md:px-12 lg:px-24 xl:px-36 ] [ max-[450px]:text-xl text-2xl sm:text-3xl lg:text-3xl ]'>
+        <div id={id || "about"} className='min-h-[100vh] flex flex-col sm:flex-row items-center max-sm:space-y-10 sm:space-x-5 md:space-x-10 lg:space-x-24 xl:space-x-16 [ md:px-12 lg:px-24 xl:px-36 ]'>
 
-            <Image src="/assets/images/user_img_bw.jpg" width={250} height={0} alt="Shivam's Picture" className='rounded-3xl'/>
+            <Image src="/assets/images/user_img_bw.jpg" width={250} height={0} alt="Shivam's Picture" className='rounded-3xl flex-shrink-0'/>
 
-            <div className='flex-grow'> 
-                <p className=' px-5 sm:font-medium text-center sm:text-start leading-[1.7] '><Skill>Software Engineer</Skill> with 1+ year of experience in full-stack development and API design. Passionate about solving complex problems and building technology that delivers measurable value. Expertise in Java, JavaScript, Golang and frameworks like <Skill>React.js</Skill> and <Skill>Next.js</Skill>.</p>
+            <div className='flex-grow px-5'>
+                <h2 className="text-sm font-mono text-accent3 mb-4 tracking-widest uppercase select-none">// About me</h2>
+                <p className='sm:font-medium text-center sm:text-start leading-[1.7] mb-8 text-lg'><Skill>Software Engineer</Skill> with 1+ year of experience in full-stack development and API design. Passionate about solving complex problems and building technology that delivers measurable value. Expertise in Java, JavaScript, Golang and frameworks like <Skill>React.js</Skill> and <Skill>Next.js</Skill>.</p>
+
+                <div className="flex flex-col gap-4">
+                    {data.skills.map(({ category, items }) => (
+                        <div key={category}>
+                            <p className="text-xs text-gray-500 uppercase tracking-wider mb-2 font-mono">{category}</p>
+                            <div className="flex flex-wrap gap-2">
+                                {items.map((skill) => (
+                                    <span key={skill} className="text-sm px-3 py-1 rounded-full border border-gray-700 text-gray-300 hover:border-accent3/60 hover:text-accent3 transition-colors duration-200">
+                                        {skill}
+                                    </span>
+                                ))}
+                            </div>
+                        </div>
+                    ))}
+                </div>
             </div>
 
         </div>

--- a/components/Contact.jsx
+++ b/components/Contact.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const Contact = ({ id, mail }) => {
   return (
-    <div id={id || "contact"} className='h-[100vh] pt-20 text-7xl flex items-center'>
+    <div id={id || "contact"} className='min-h-[100vh] pt-20 text-7xl flex items-center'>
         <div className='text-center'>
           <h1 className='mb-5 font-bold'>Get in touch</h1>
           <p className='text-lg mt-2 text-primary2/55 max-w-2xl leading-[1.8] font-medium'>My inbox is always open. Whether you have a question or just want to say hello, I'll try my best to get back to you! Feel free to mail me about any relevant job updates.</p>

--- a/components/Contact.jsx
+++ b/components/Contact.jsx
@@ -1,12 +1,19 @@
-import React from 'react'
+import data from '../data.json'
 
 const Contact = ({ id, mail }) => {
   return (
-    <div id={id || "contact"} className='min-h-[100vh] pt-20 text-7xl flex items-center'>
-        <div className='text-center'>
-          <h1 className='mb-5 font-bold'>Get in touch</h1>
-          <p className='text-lg mt-2 text-primary2/55 max-w-2xl leading-[1.8] font-medium'>My inbox is always open. Whether you have a question or just want to say hello, I'll try my best to get back to you! Feel free to mail me about any relevant job updates.</p>
-          <a className='p-5 inline-block bg-accent1 text-inherit text-4xl rounded-lg hover:rounded-xl active:rounded-2xl mt-8 font-extrabold' href={`mailto:${mail}`}>Mail Me</a>
+    <div id={id || "contact"} className='min-h-[100vh] pt-20 flex items-center justify-center'>
+        <div className='text-center max-w-2xl px-4'>
+          <h2 className="text-sm font-mono text-accent3 mb-4 tracking-widest uppercase select-none">// Contact</h2>
+          <h1 className='mb-5 font-bold text-5xl sm:text-7xl'>Get in touch</h1>
+          <p className='text-lg mt-2 text-primary2/55 leading-[1.8] font-medium'>My inbox is always open. Whether you have a question or just want to say hello, I'll try my best to get back to you! Feel free to mail me about any relevant job updates.</p>
+          <p className='text-sm text-gray-600 mt-2'>Typically responds within 24 hours.</p>
+          <div className="flex flex-wrap justify-center gap-4 mt-8">
+            <a className='p-4 inline-block bg-accent1 text-primary2 text-xl font-extrabold rounded-lg hover:bg-accent3 active:scale-95 transition-all duration-150' href={`mailto:${mail}`}>Mail Me</a>
+            {data.linkedinUrl && (
+              <a className='p-4 inline-block border border-gray-600 text-primary2 text-xl font-extrabold rounded-lg hover:border-accent3 hover:text-accent3 active:scale-95 transition-all duration-150' href={data.linkedinUrl} target="_blank" rel="noopener noreferrer">LinkedIn</a>
+            )}
+          </div>
         </div>
     </div>
   )

--- a/components/Experience.jsx
+++ b/components/Experience.jsx
@@ -2,15 +2,18 @@ import data from "../data.json"
 
 const Experience = ({ id }) => {
   return (
-    <div id={id || 'experience'} className='min-h-[100vh] text-7xl font-bold flex items-center'>
-        <ExperienceList />
+    <div id={id || 'experience'} className='min-h-[100vh] font-bold flex items-center'>
+        <div className="w-[80vw] py-28">
+            <h2 className="text-sm font-mono text-accent3 mb-2 tracking-widest uppercase select-none">// Experience</h2>
+            <ExperienceList />
+        </div>
     </div>
   )
 }
 
 const ExperienceList = () => {
     return (
-        <div className="text-xl h-[100%] flex flex-col space-y-6 w-[80vw] py-28">
+        <div className="text-xl flex flex-col space-y-6">
             {data.experience.map((exp, idx) => (
                 <ExperienceCard key={idx} {...exp} />
             ))}
@@ -18,13 +21,40 @@ const ExperienceList = () => {
     )
 }
 
-const ExperienceCard = ({ title, company, duration, description }) => {
+const ExperienceCard = ({ title, company, companyUrl, duration, description, tags }) => {
     return (
-        <div className="m-0 px-12 py-8 bg-black hover:bg-gray-700 border border-gray-700 rounded-lg">
-            <h2 className="text-primary2 select-none"><span className="text-accent3 text-xl">{title}</span> - {company} ({duration})</h2>
-            <ul className="list-disc list-inside text-gray-400 select-none mt-2 space-y-1">
+        <div className="px-8 py-6 bg-black hover:bg-gray-900 border border-gray-700 rounded-lg transition-colors duration-200">
+            <div className="flex items-center gap-3 mb-1">
+                <img
+                    src={`https://www.google.com/s2/favicons?domain=${new URL(companyUrl).hostname}&sz=32`}
+                    alt={`${company} logo`}
+                    width={20}
+                    height={20}
+                    className="rounded-sm"
+                />
+                <a
+                    href={companyUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-base text-gray-400 hover:text-primary2 transition-colors"
+                >
+                    {company}
+                </a>
+                <span className="text-gray-600 text-sm ml-auto">{duration}</span>
+            </div>
+            <h2 className="text-accent3 text-xl font-bold mb-3 select-none">{title}</h2>
+            <ul className="list-disc list-inside text-gray-400 select-none space-y-1 text-base">
                 {description.map((item, i) => <li key={i}>{item}</li>)}
             </ul>
+            {tags && tags.length > 0 && (
+                <div className="flex flex-wrap gap-2 mt-4">
+                    {tags.map((tag) => (
+                        <span key={tag} className="text-xs px-2 py-1 rounded-full border border-accent3/40 text-accent3/80">
+                            {tag}
+                        </span>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/components/Experience.jsx
+++ b/components/Experience.jsx
@@ -1,8 +1,8 @@
+import data from "../data.json"
 
 const Experience = ({ id }) => {
   return (
     <div id={id || 'experience'} className='min-h-[100vh] text-7xl font-bold flex items-center'>
-        {/* <h2 className="text-5xl">Experience</h2> */}
         <ExperienceList />
     </div>
   )
@@ -11,20 +11,9 @@ const Experience = ({ id }) => {
 const ExperienceList = () => {
     return (
         <div className="text-xl h-[100%] flex flex-col space-y-6 w-[80vw] py-28">
-            <ExperienceCard
-                title="Software Engineer"
-                company="Newgen Software Technologies Limited"
-                duration="Jul 2025 - Present"
-                description="• Developed and maintained backend utilities, API integrations, Servlets and server-side
-validations using Enterprise Java (Jakarta EE); contributed to front-end validations using
-JavaScript and ensured seamless functionality across modules."
-            />
-            <ExperienceCard
-                title="Software Engineer Trainee"
-                company="Newgen Software Technologies Limited"
-                duration="Feb 2025 - Jun 2025"
-                description="Collaborated with cross-functional teams to develop and maintain web applications."
-            />
+            {data.experience.map((exp, idx) => (
+                <ExperienceCard key={idx} {...exp} />
+            ))}
         </div>
     )
 }
@@ -33,7 +22,9 @@ const ExperienceCard = ({ title, company, duration, description }) => {
     return (
         <div className="m-0 px-12 py-8 bg-black hover:bg-gray-700 border border-gray-700 rounded-lg">
             <h2 className="text-primary2 select-none"><span className="text-accent3 text-xl">{title}</span> - {company} ({duration})</h2>
-            <p className="text-gray-400 select-none">{description}</p>
+            <ul className="list-disc list-inside text-gray-400 select-none mt-2 space-y-1">
+                {description.map((item, i) => <li key={i}>{item}</li>)}
+            </ul>
         </div>
     );
 }

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -15,9 +15,14 @@ const Home = ({ id, }) => {
             <h1 className='text-5xl font-semibold text-stone-300/30 flex flex-col items-start'><span>Hi! My name is</span><span className='text-primary2 text-9xl'>Shivam Verma</span></h1>
             </span>
 
-            {/* <span className='polygon' id='p1'><img src="/assets/images/polygon.png" /></span> */}
-
             <SocialLinks/>
+
+            {/* Scroll cue */}
+            <a href="#about" aria-label="Scroll to About section" className="absolute bottom-10 left-1/2 -translate-x-1/2 flex flex-col items-center animate-bounce text-primary2/50 hover:text-primary2 transition-colors z-10">
+                <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="M12 5v14M5 12l7 7 7-7"/>
+                </svg>
+            </a>
         </div>
     )
 }

--- a/components/Home.jsx
+++ b/components/Home.jsx
@@ -1,18 +1,31 @@
 import React from 'react'
 import SocialLinks from './SocialLinks'
+import data from '../data.json'
 
-const Home = ({ id, }) => {
+const Home = ({ id }) => {
     return (
-        <div id={id || "home"} className="h-[100vh] sm:h-[86vh] w-full flex items-center justify-center">
+        <div id={id || "home"} className="h-[100vh] sm:h-[100vh] w-full flex items-center justify-center">
 
             {/* for smaller screens */}
             <span className="min-[930px]:hidden z-10">
             <h1 className="text-[8vw] font-semibold text-primary text-stone-300/30 pt-12">Hi!<br/>My name is<br/><span className="text-[10vw] text-primary2">Shivam Verma</span></h1>
+            {data.openToWork && (
+                <span className="inline-flex items-center gap-1.5 mt-3 text-xs font-medium px-3 py-1 rounded-full bg-green-900/40 border border-green-500/40 text-green-400">
+                    <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse" />
+                    Open to work
+                </span>
+            )}
             </span>
 
             {/* for larger screens */}
-            <span className="hidden min-[930px]:flex absolute top-[39%] z-10">
+            <span className="hidden min-[930px]:flex flex-col absolute top-[39%] z-10">
             <h1 className='text-5xl font-semibold text-stone-300/30 flex flex-col items-start'><span>Hi! My name is</span><span className='text-primary2 text-9xl'>Shivam Verma</span></h1>
+            {data.openToWork && (
+                <span className="inline-flex items-center gap-1.5 mt-4 text-sm font-medium px-4 py-1.5 rounded-full bg-green-900/40 border border-green-500/40 text-green-400 w-fit">
+                    <span className="w-2 h-2 rounded-full bg-green-400 animate-pulse" />
+                    Open to work
+                </span>
+            )}
             </span>
 
             <SocialLinks/>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -1,9 +1,7 @@
 "use client"
-import Link from 'next/link'
 import Image from 'next/image'
 import resume from "../public/assets/icons/resume_2.png"
 import { useState } from 'react'
-import SmoothLink from './SmoothLink'
 import { Jost } from 'next/font/google'
 
 const font = Jost({subsets: ['latin'], weight: ['200', '300', '400', '500', '600', '700', '800']})
@@ -22,13 +20,13 @@ const Navbar = () => {
         <ul className="flex justify-between items-center navbar w-full">
             {NAV_ITEMS.map((item) => (
                 <li key={item} className='navbar-list-items'>
-                    <SmoothLink className="cs-navItem" href={`#${item}`}>{item.charAt(0).toUpperCase() + item.slice(1)}</SmoothLink>
+                    <a className="cs-navItem" href={`#${item}`}>{item.charAt(0).toUpperCase() + item.slice(1)}</a>
                 </li>
             ))}
         </ul>
       </nav>
       <div className="flex items-center gap-3">
-        <Link className="flex flex-col items-center" href="https://drive.google.com/file/d/1GXF4IIIzq95SBXYRvfy_F8jqTvpFKbar/view?usp=sharing" target="_blank" rel="noopener noreferrer"><Image src={resume} alt='resume link' width={35}/>Resume</Link>
+        <a className="flex flex-col items-center" href="https://drive.google.com/file/d/1GXF4IIIzq95SBXYRvfy_F8jqTvpFKbar/view?usp=sharing" target="_blank" rel="noopener noreferrer"><Image src={resume} alt='resume link' width={35}/>Resume</a>
         <button
           className="min-[850px]:hidden flex flex-col justify-center items-center gap-[5px] w-8 h-8"
           aria-label="Toggle navigation menu"
@@ -46,9 +44,9 @@ const Navbar = () => {
         <ul className="flex flex-col items-center py-4 gap-2">
           {NAV_ITEMS.map((item) => (
             <li key={item} className="w-full text-center" onClick={() => setMobileOpen(false)}>
-              <SmoothLink className="cs-navItem block py-3 text-primary2" href={`#${item}`}>
+              <a className="cs-navItem block py-3 text-primary2" href={`#${item}`}>
                 {item.charAt(0).toUpperCase() + item.slice(1)}
-              </SmoothLink>
+              </a>
             </li>
           ))}
         </ul>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -1,7 +1,7 @@
 "use client"
 import Image from 'next/image'
 import resume from "../public/assets/icons/resume_2.png"
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { Jost } from 'next/font/google'
 
 const font = Jost({subsets: ['latin'], weight: ['200', '300', '400', '500', '600', '700', '800']})
@@ -10,6 +10,21 @@ const NAV_ITEMS = ['home', 'about', 'experience', 'projects', 'contact']
 
 const Navbar = () => {
   const [mobileOpen, setMobileOpen] = useState(false)
+  const [activeSection, setActiveSection] = useState('home')
+
+  useEffect(() => {
+    const observers = NAV_ITEMS.map((item) => {
+      const el = document.getElementById(item)
+      if (!el) return null
+      const observer = new IntersectionObserver(
+        ([entry]) => { if (entry.isIntersecting) setActiveSection(item) },
+        { rootMargin: '-40% 0px -55% 0px' }
+      )
+      observer.observe(el)
+      return observer
+    })
+    return () => observers.forEach((o) => o?.disconnect())
+  }, [])
 
   return (
     <>
@@ -20,7 +35,12 @@ const Navbar = () => {
         <ul className="flex justify-between items-center navbar w-full">
             {NAV_ITEMS.map((item) => (
                 <li key={item} className='navbar-list-items'>
-                    <a className="cs-navItem" href={`#${item}`}>{item.charAt(0).toUpperCase() + item.slice(1)}</a>
+                    <a
+                        className={`cs-navItem ${activeSection === item ? 'text-accent3' : ''}`}
+                        href={`#${item}`}
+                    >
+                        {item.charAt(0).toUpperCase() + item.slice(1)}
+                    </a>
                 </li>
             ))}
         </ul>
@@ -44,7 +64,7 @@ const Navbar = () => {
         <ul className="flex flex-col items-center py-4 gap-2">
           {NAV_ITEMS.map((item) => (
             <li key={item} className="w-full text-center" onClick={() => setMobileOpen(false)}>
-              <a className="cs-navItem block py-3 text-primary2" href={`#${item}`}>
+              <a className={`cs-navItem block py-3 ${activeSection === item ? 'text-accent3' : 'text-primary2'}`} href={`#${item}`}>
                 {item.charAt(0).toUpperCase() + item.slice(1)}
               </a>
             </li>

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -2,50 +2,59 @@
 import Link from 'next/link'
 import Image from 'next/image'
 import resume from "../public/assets/icons/resume_2.png"
-import { useEffect } from 'react'
+import { useState } from 'react'
 import SmoothLink from './SmoothLink'
 import { Jost } from 'next/font/google'
-// import { useRef } from 'react'
 
 const font = Jost({subsets: ['latin'], weight: ['200', '300', '400', '500', '600', '700', '800']})
 
+const NAV_ITEMS = ['home', 'about', 'experience', 'projects', 'contact']
+
 const Navbar = () => {
-  // const overlay = useRef(null)
-  // const list_items = useRef(null);
-  // overlay.current.innerHTML = ""
-
-  // useEffect(() => {
-  //   const overlay = document.getElementById("overlay")
-  //   const nav_list = [...document.getElementsByClassName("navbar-list-items")]
-
-  //   nav_list.forEach(listItem => {
-  //     listItem.addEventListener('hover', () => {
-  //       overlay.classList.add('active')
-  //       console.log('here')
-  //     })
-  //   })
-  // },[])
-
-  const handleMouseOver = (e) => {
-    // console.log(e);
-    // document.getElementById('overlay').classList.add('active')
-  }
+  const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
+    <>
     <div className={`fixed z-20 flex w-full h-28 px-4 md:px-[34px] py-6 justify-between font-semibold text-lg items-center ${font.className}`}>
       <div className='text-2xl font-extrabold cursor-pointer'>Shivam</div>
       <nav className='cs-navbar font-bold ice-frost shadow-black/70'>
         <div className="overlay" id="overlay"></div>
         <ul className="flex justify-between items-center navbar w-full">
-            <li className='navbar-list-items ml-[2.8px]' onMouseOver={handleMouseOver}><SmoothLink className="cs-navItem" href="#home">Home</SmoothLink></li>
-            <li className='navbar-list-items ' onMouseOver={handleMouseOver}><SmoothLink className="cs-navItem" href="#about">About</SmoothLink></li>
-            <li className='navbar-list-items tooltip' onMouseOver={handleMouseOver}><SmoothLink className="cs-navItem" href="#experience">Experience</SmoothLink></li>
-            <li className='navbar-list-items ' onMouseOver={handleMouseOver}><SmoothLink className="cs-navItem" href="#projects">Projects</SmoothLink></li>
-            <li className='navbar-list-items mr-[2.8px]' onMouseOver={handleMouseOver}><SmoothLink className="cs-navItem" href="#contact">Contact</SmoothLink></li>
+            {NAV_ITEMS.map((item) => (
+                <li key={item} className='navbar-list-items'>
+                    <SmoothLink className="cs-navItem" href={`#${item}`}>{item.charAt(0).toUpperCase() + item.slice(1)}</SmoothLink>
+                </li>
+            ))}
         </ul>
       </nav>
-      <Link className="flex flex-col items-center" href="https://drive.google.com/file/d/1GXF4IIIzq95SBXYRvfy_F8jqTvpFKbar/view?usp=sharing" target="_blank"><Image src={resume} alt='resume link' width={35}/>Resume</Link>
-    </div> 
+      <div className="flex items-center gap-3">
+        <Link className="flex flex-col items-center" href="https://drive.google.com/file/d/1GXF4IIIzq95SBXYRvfy_F8jqTvpFKbar/view?usp=sharing" target="_blank" rel="noopener noreferrer"><Image src={resume} alt='resume link' width={35}/>Resume</Link>
+        <button
+          className="min-[850px]:hidden flex flex-col justify-center items-center gap-[5px] w-8 h-8"
+          aria-label="Toggle navigation menu"
+          aria-expanded={mobileOpen}
+          onClick={() => setMobileOpen(!mobileOpen)}
+        >
+          <span className={`block w-6 h-0.5 bg-primary2 transition-all duration-300 ${mobileOpen ? 'translate-y-[7px] rotate-45' : ''}`} />
+          <span className={`block w-6 h-0.5 bg-primary2 transition-all duration-300 ${mobileOpen ? 'opacity-0' : ''}`} />
+          <span className={`block w-6 h-0.5 bg-primary2 transition-all duration-300 ${mobileOpen ? '-translate-y-[7px] -rotate-45' : ''}`} />
+        </button>
+      </div>
+    </div>
+    {mobileOpen && (
+      <div className={`min-[850px]:hidden fixed z-10 top-28 left-0 w-full ice-frost border-b border-white/10 ${font.className}`}>
+        <ul className="flex flex-col items-center py-4 gap-2">
+          {NAV_ITEMS.map((item) => (
+            <li key={item} className="w-full text-center" onClick={() => setMobileOpen(false)}>
+              <SmoothLink className="cs-navItem block py-3 text-primary2" href={`#${item}`}>
+                {item.charAt(0).toUpperCase() + item.slice(1)}
+              </SmoothLink>
+            </li>
+          ))}
+        </ul>
+      </div>
+    )}
+    </>
   )
 }
 

--- a/components/Navbar.jsx
+++ b/components/Navbar.jsx
@@ -29,7 +29,16 @@ const Navbar = () => {
   return (
     <>
     <div className={`fixed z-20 flex w-full h-28 px-4 md:px-[34px] py-6 justify-between font-semibold text-lg items-center ${font.className}`}>
-      <div className='text-2xl font-extrabold cursor-pointer'>Shivam</div>
+      <a href="#home" aria-label="Go to top" className="cursor-pointer flex-shrink-0">
+        <svg width="48" height="36" viewBox="0 0 48 36" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          {/* S bold */}
+          <text x="0" y="26" fontFamily="'Jost', sans-serif" fontSize="26" fontWeight="700" fill="white">S</text>
+          {/* V light */}
+          <text x="23" y="26" fontFamily="'Jost', sans-serif" fontSize="26" fontWeight="200" fill="white">V</text>
+          {/* Thin underline accent under S only */}
+          <line x1="1" y1="31" x2="19" y2="31" stroke="white" strokeWidth="1.5" strokeLinecap="round"/>
+        </svg>
+      </a>
       <nav className='cs-navbar font-bold ice-frost shadow-black/70'>
         <div className="overlay" id="overlay"></div>
         <ul className="flex justify-between items-center navbar w-full">

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 
 const RepoIcon = () => (
-    <svg className="inline mr-2 align-middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+    <svg className="inline mr-2 align-text-bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
         <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
     </svg>
 )

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -35,7 +35,7 @@ const Projects = ({ id }) => {
             {loading && (
                 <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
                     {Array.from({length: 6}).map((_, i) => (
-                        <div key={i} className="flex flex-col p-6 m-2 border rounded-lg bg-black border-gray-700 animate-pulse h-36"/>
+                        <div key={i} className="flex flex-col p-6 m-2 border rounded-lg bg-gray-800 border-gray-700 animate-pulse h-36 lg:min-w-[300px]"/>
                     ))}
                 </div>
             )}

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -3,8 +3,12 @@
 import { useEffect, useState } from "react";
 
 const RepoIcon = () => (
-    <svg className="inline mr-2 align-text-bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
-        <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+    // <svg className="inline mr-2 align-text-bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+    //     <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+    // </svg>
+    <svg className="inline mr-2 align-text-bottom" width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true">
+        <path fill-rule="evenodd" d="M3 2.75A2.75 2.75 0 015.75 0h14.5a.75.75 0 01.75.75v20.5a.75.75 0 01-.75.75h-6a.75.75 0 010-1.5h5.25v-4H6A1.5 1.5 0 004.5 18v.75c0 .716.43 1.334 1.05 1.605a.75.75 0 01-.6 1.374A3.25 3.25 0 013 18.75v-16zM19.5 1.5V15H6c-.546 0-1.059.146-1.5.401V2.75c0-.69.56-1.25 1.25-1.25H19.5z"/>
+        <path d="M7 18.25a.25.25 0 01.25-.25h5a.25.25 0 01.25.25v5.01a.25.25 0 01-.397.201l-2.206-1.604a.25.25 0 00-.294 0L7.397 23.46a.25.25 0 01-.397-.2v-5.01z"/>
     </svg>
 )
 
@@ -46,7 +50,7 @@ const Projects = ({ id }) => {
                 <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
                 {repos.map((repo) => (
                     <a href={repo.node.url} target="_blank" rel="noopener noreferrer" key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-700">
-                        <h5 className="mb-2 text-2xl font-bold text-primary2 flex items-center gap-2"><RepoIcon/><span className="truncate">{repo.node.name}</span></h5>
+                        <h5 className="mb-2 text-2xl font-bold text-primary2 flex items-center"><RepoIcon/><span className="truncate">{repo.node.name}</span></h5>
                         <p className="font-normal text-gray-400 w-full truncate-box mb-2 text-left">{repo.node.description}</p>
                         <div className="flex items-end flex-grow font-medium text-gray-400">
                             <div>

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useState } from "react";
 
+const StarIcon = () => (
+    <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" className="inline mr-1">
+        <path d="M12 2l3.09 6.26L22 9.27l-5 4.87 1.18 6.88L12 17.77l-6.18 3.25L7 14.14 2 9.27l6.91-1.01L12 2z"/>
+    </svg>
+)
+
 const RepoIcon = () => (
-    // <svg className="inline mr-2 align-text-bottom" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
-    //     <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
-    // </svg>
-    <svg className="inline mr-2 align-text-bottom" width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true">
-        <path fill-rule="evenodd" d="M3 2.75A2.75 2.75 0 015.75 0h14.5a.75.75 0 01.75.75v20.5a.75.75 0 01-.75.75h-6a.75.75 0 010-1.5h5.25v-4H6A1.5 1.5 0 004.5 18v.75c0 .716.43 1.334 1.05 1.605a.75.75 0 01-.6 1.374A3.25 3.25 0 013 18.75v-16zM19.5 1.5V15H6c-.546 0-1.059.146-1.5.401V2.75c0-.69.56-1.25 1.25-1.25H19.5z"/>
+    <svg className="flex-shrink-0" width="20" height="20" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="currentColor" aria-hidden="true">
+        <path fillRule="evenodd" d="M3 2.75A2.75 2.75 0 015.75 0h14.5a.75.75 0 01.75.75v20.5a.75.75 0 01-.75.75h-6a.75.75 0 010-1.5h5.25v-4H6A1.5 1.5 0 004.5 18v.75c0 .716.43 1.334 1.05 1.605a.75.75 0 01-.6 1.374A3.25 3.25 0 013 18.75v-16zM19.5 1.5V15H6c-.546 0-1.059.146-1.5.401V2.75c0-.69.56-1.25 1.25-1.25H19.5z"/>
         <path d="M7 18.25a.25.25 0 01.25-.25h5a.25.25 0 01.25.25v5.01a.25.25 0 01-.397.201l-2.206-1.604a.25.25 0 00-.294 0L7.397 23.46a.25.25 0 01-.397-.2v-5.01z"/>
     </svg>
 )
@@ -16,52 +19,91 @@ const Projects = ({ id }) => {
 
     const [repos, setRepos] = useState([]);
     const [loading, setLoading] = useState(true);
-    const [error, setError] = useState(false);
+    const [error, setError] = useState(null);
 
-    useEffect(() => {
-        const getRepos = async() => {
-            const result = await fetch("/api/get-repos", { method: 'GET' })
-            return result.json()
-        }
-        getRepos()
+    const fetchRepos = () => {
+        setLoading(true)
+        setError(null)
+        fetch("/api/get-repos", { method: 'GET' })
+            .then((res) => {
+                if (!res.ok) throw new Error(`Server error: ${res.status}`)
+                return res.json()
+            })
             .then((r) => {
-                setRepos(r.data?.user?.pinnedItems?.edges ?? [])
+                const edges = r.data?.user?.pinnedItems?.edges
+                if (!edges) throw new Error('No data returned')
+                setRepos(edges)
                 setLoading(false)
             })
-            .catch(() => {
-                setError(true)
+            .catch((err) => {
+                setError(err.message ?? 'Unknown error')
                 setLoading(false)
             })
-    },[]);
+    }
+
+    useEffect(() => { fetchRepos() }, []);
         
     return (
         <div id={id || "projects"} className='min-h-[100vh] font-bold flex justify-center items-center'>
-            {loading && (
-                <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
-                    {Array.from({length: 6}).map((_, i) => (
-                        <div key={i} className="flex flex-col p-6 m-2 border rounded-lg bg-gray-800 border-gray-700 animate-pulse h-36 lg:min-w-[300px]"/>
-                    ))}
-                </div>
-            )}
-            {error && (
-                <p className="text-gray-400 text-xl font-normal">Could not load projects. Please try again later.</p>
-            )}
-            {!loading && !error && (
-                <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
-                {repos.map((repo) => (
-                    <a href={repo.node.url} target="_blank" rel="noopener noreferrer" key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-700">
-                        <h5 className="mb-2 text-2xl font-bold text-primary2 flex items-center"><RepoIcon/><span className="truncate">{repo.node.name}</span></h5>
-                        <p className="font-normal text-gray-400 w-full truncate-box mb-2 text-left">{repo.node.description}</p>
-                        <div className="flex items-end flex-grow font-medium text-gray-400">
-                            <div>
-                                <div style={{backgroundColor: `${repo.node.primaryLanguage?.color}`}} className="inline-block mr-2 w-3 h-3 rounded-full"/>
-                                {repo.node.primaryLanguage?.name}
+            <div className="w-[80vw] max-w-screen-xl py-28">
+                <h2 className="text-sm font-mono text-accent3 mb-6 tracking-widest uppercase select-none">// Projects</h2>
+                {loading && (
+                    <div className="grid grid-rows-6 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
+                        {Array.from({length: 6}).map((_, i) => (
+                            <div key={i} className="flex flex-col p-6 m-2 border rounded-lg bg-gray-800 border-gray-700 animate-pulse h-36"/>
+                        ))}
+                    </div>
+                )}
+                {error && (
+                    <div className="flex flex-col items-center gap-4 py-16 text-center">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" className="text-gray-600" aria-hidden="true">
+                            <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+                        </svg>
+                        <p className="text-gray-400 text-lg font-normal">Could not load projects.</p>
+                        <p className="text-gray-600 text-sm font-normal">{error}</p>
+                        <button
+                            onClick={fetchRepos}
+                            className="mt-2 px-5 py-2 text-sm font-semibold border border-gray-600 text-primary2 rounded-lg hover:border-accent3 hover:text-accent3 transition-colors duration-150"
+                        >
+                            Try again
+                        </button>
+                    </div>
+                )}
+                {!loading && !error && (
+                    <div className="grid grid-rows-6 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
+                    {repos.map((repo) => (
+                        <div key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-900 transition-colors duration-200">
+                            <h5 className="mb-2 text-xl font-bold text-primary2 flex items-center gap-2">
+                                <RepoIcon/>
+                                <span className="truncate">{repo.node.name}</span>
+                            </h5>
+                            <p className="font-normal text-gray-400 w-full truncate-box mb-3 text-left text-sm">{repo.node.description}</p>
+                            <div className="flex items-center justify-between mt-auto font-medium text-gray-400 text-sm">
+                                <div className="flex items-center gap-3">
+                                    {repo.node.primaryLanguage && (
+                                        <span className="flex items-center gap-1">
+                                            <span style={{backgroundColor: repo.node.primaryLanguage.color}} className="inline-block w-3 h-3 rounded-full"/>
+                                            {repo.node.primaryLanguage.name}
+                                        </span>
+                                    )}
+                                    {repo.node.stargazerCount > 0 && (
+                                        <span className="flex items-center text-yellow-500/70">
+                                            <StarIcon/>{repo.node.stargazerCount}
+                                        </span>
+                                    )}
+                                </div>
+                                <div className="flex items-center gap-2 text-xs">
+                                    {repo.node.homepageUrl && (
+                                        <a href={repo.node.homepageUrl} target="_blank" rel="noopener noreferrer" className="text-accent3/80 hover:text-accent3 border border-accent3/30 hover:border-accent3/60 px-2 py-0.5 rounded transition-colors">Live</a>
+                                    )}
+                                    <a href={repo.node.url} target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-primary2 border border-gray-700 hover:border-gray-500 px-2 py-0.5 rounded transition-colors">Code</a>
+                                </div>
                             </div>
                         </div>
-                    </a>
-                ))}
-                </div>
-            )}
+                    ))}
+                    </div>
+                )}
+            </div>
         </div>
     )
 }

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -46,7 +46,7 @@ const Projects = ({ id }) => {
                 <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
                 {repos.map((repo) => (
                     <a href={repo.node.url} target="_blank" rel="noopener noreferrer" key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-700">
-                        <h5 className="mb-2 text-2xl font-bold text-primary2 truncate"><RepoIcon/>{repo.node.name}</h5>
+                        <h5 className="mb-2 text-2xl font-bold text-primary2 flex items-center gap-2"><RepoIcon/><span className="truncate">{repo.node.name}</span></h5>
                         <p className="font-normal text-gray-400 w-full truncate-box mb-2 text-left">{repo.node.description}</p>
                         <div className="flex items-end flex-grow font-medium text-gray-400">
                             <div>

--- a/components/Projects.jsx
+++ b/components/Projects.jsx
@@ -2,37 +2,62 @@
 
 import { useEffect, useState } from "react";
 
+const RepoIcon = () => (
+    <svg className="inline mr-2 align-middle" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="20" height="20" fill="currentColor" aria-hidden="true">
+        <path d="M2 2.5A2.5 2.5 0 0 1 4.5 0h8.75a.75.75 0 0 1 .75.75v12.5a.75.75 0 0 1-.75.75h-2.5a.75.75 0 0 1 0-1.5h1.75v-2h-8a1 1 0 0 0-.714 1.7.75.75 0 1 1-1.072 1.05A2.495 2.495 0 0 1 2 11.5Zm10.5-1h-8a1 1 0 0 0-1 1v6.708A2.486 2.486 0 0 1 4.5 9h8Z"/>
+    </svg>
+)
+
 const Projects = ({ id }) => {
 
     const [repos, setRepos] = useState([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState(false);
 
     useEffect(() => {
         const getRepos = async() => {
-            // console.log(process.env.NEXT_PUBLIC_GITHUB_ACCESS_TOKEN)
-            const result = await fetch("/api/get-repos", {
-                method: 'GET',
-            })
+            const result = await fetch("/api/get-repos", { method: 'GET' })
             return result.json()
         }
-        getRepos().then((r) => {
-            setRepos(r.data?.user?.pinnedItems?.edges)
-        })
+        getRepos()
+            .then((r) => {
+                setRepos(r.data?.user?.pinnedItems?.edges ?? [])
+                setLoading(false)
+            })
+            .catch(() => {
+                setError(true)
+                setLoading(false)
+            })
     },[]);
         
     return (
         <div id={id || "projects"} className='min-h-[100vh] font-bold flex justify-center items-center'>
-            {/* <div className="flex flex-wrap justify-center"> */}
-            <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
-            {repos && repos.map((repo) => (
-                // <div className="w-80 bg-">{repo.name}</div>
-                <a href={repo.node.url} target="_blank" key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-700">
-                    <h5 className="mb-2 text-2xl font-bold text-primary2 truncate"><img className="inline mr-2" width="24" height="24" src="https://img.icons8.com/windows/32/E7E5E4/repository.png" alt="repository"/>{repo.node.name}</h5>
-                    <p className="font-normal text-gray-400 w-full truncate-box mb-2 text-left">{repo.node.description}</p>
-                    <div className="flex items-end flex-grow font-medium text-gray-400"><div><div style={{backgroundColor: `${repo.node.primaryLanguage.color}`}} className="inline-block mr-2 w-3 h-3 rounded-full"></div>{repo.node.primaryLanguage.name}</div></div>
-                </a>
-            ))}
-            {/* <object className="bg-black" type="image/svg+xml" data="https://gh-card.dev/repos/stoppieboy/promptopia.svg?fullname=&link_target=_blank"></object> */}
-            </div>
+            {loading && (
+                <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
+                    {Array.from({length: 6}).map((_, i) => (
+                        <div key={i} className="flex flex-col p-6 m-2 border rounded-lg bg-black border-gray-700 animate-pulse h-36"/>
+                    ))}
+                </div>
+            )}
+            {error && (
+                <p className="text-gray-400 text-xl font-normal">Could not load projects. Please try again later.</p>
+            )}
+            {!loading && !error && (
+                <div className="grid px-6 grid-rows-6 min-[540px]:px-0 min-[540px]:grid-rows-3 min-[540px]:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2 max-w-screen-xl">
+                {repos.map((repo) => (
+                    <a href={repo.node.url} target="_blank" rel="noopener noreferrer" key={repo.node.id} className="flex flex-col p-6 m-2 border rounded-lg shadow bg-black border-gray-700 hover:bg-gray-700">
+                        <h5 className="mb-2 text-2xl font-bold text-primary2 truncate"><RepoIcon/>{repo.node.name}</h5>
+                        <p className="font-normal text-gray-400 w-full truncate-box mb-2 text-left">{repo.node.description}</p>
+                        <div className="flex items-end flex-grow font-medium text-gray-400">
+                            <div>
+                                <div style={{backgroundColor: `${repo.node.primaryLanguage?.color}`}} className="inline-block mr-2 w-3 h-3 rounded-full"/>
+                                {repo.node.primaryLanguage?.name}
+                            </div>
+                        </div>
+                    </a>
+                ))}
+                </div>
+            )}
         </div>
     )
 }

--- a/components/Skill.jsx
+++ b/components/Skill.jsx
@@ -1,7 +1,7 @@
 
 const Skill = ({children}) => {
   return (
-    <span className="text-accent1 font-extrabold text-[36px]">
+    <span className="text-accent3 font-extrabold">
         {children}
     </span>
   )

--- a/components/SmoothLink.jsx
+++ b/components/SmoothLink.jsx
@@ -1,8 +1,0 @@
-import smoothScroll from "@/Utility/smoothScroll"
-import Link from "next/link"
-
-const SmoothLink = (props) => {
-    return <Link {...props} onClick={smoothScroll}>{props.children}</Link>
-}
-
-export default SmoothLink;

--- a/components/SocialLinks.jsx
+++ b/components/SocialLinks.jsx
@@ -20,7 +20,7 @@ const SocialLinks = () => {
 
         <div className="absolute right-10 bottom-10 flex flex-col p-3 gap-8 rounded-3xl">
             {links && links.map((link, idx) => (
-                <Link key={idx} href={link.href} target="_blank"><Image src={`/assets/icons/${link.name}.svg`} alt={`${link.name} icon`} width={SIZE} height={SIZE}/></Link>
+                <Link key={idx} href={link.href} target="_blank" rel="noopener noreferrer" aria-label={`Visit ${link.name} profile`}><Image src={`/assets/icons/${link.name}.svg`} alt={`${link.name} icon`} width={SIZE} height={SIZE}/></Link>
             ))}
         </div>
     )

--- a/components/SocialLinks.jsx
+++ b/components/SocialLinks.jsx
@@ -12,14 +12,8 @@ const SocialLinks = () => {
     const SIZE = 30;
 
     return (
-        // <div className="absolute bottom-10 flex p-3 gap-4 border-[3px] border-white rounded-3xl bg-black">
-        //     {links && links.map((link, idx) => (
-        //         <Link key={idx} href={link.href} target="_blank"><Image src={`/assets/icons/${link.name}.svg`} alt={`${link.name} icon`} width={SIZE} height={SIZE}/></Link>
-        //     ))}
-        // </div>
-
         <div className="absolute right-10 bottom-10 flex flex-col p-3 gap-8 rounded-3xl">
-            {links && links.map((link, idx) => (
+            {links.map((link, idx) => (
                 <Link key={idx} href={link.href} target="_blank" rel="noopener noreferrer" aria-label={`Visit ${link.name} profile`}><Image src={`/assets/icons/${link.name}.svg`} alt={`${link.name} icon`} width={SIZE} height={SIZE}/></Link>
             ))}
         </div>

--- a/data.json
+++ b/data.json
@@ -1,11 +1,21 @@
 {
     "about_text": "Software Engineer with 1+ year of experience in full-stack development and API design. Passionate about solving complex problems and building technology that delivers measurable value. Expertise in Java, JavaScript, Golang and frameworks like React.js and Next.js.",
     "email": "shivamv1332@gmail.com",
+    "linkedinUrl": "https://linkedin.com/in/shivam3004",
+    "openToWork": true,
+    "skills": [
+        { "category": "Languages", "items": ["Java", "JavaScript", "TypeScript", "Golang"] },
+        { "category": "Frameworks", "items": ["React.js", "Next.js", "Node.js"] },
+        { "category": "Databases", "items": ["MySQL", "MongoDB"] },
+        { "category": "Tools", "items": ["Git", "REST APIs", "GraphQL"] }
+    ],
     "experience": [
         {
             "title": "Software Engineer",
             "company": "Newgen Software Technologies Limited",
+            "companyUrl": "https://newgensoft.com",
             "duration": "Jul 2025 - Present",
+            "tags": ["Jakarta EE", "Java", "JavaScript", "REST APIs", "Servlets"],
             "description": [
                 "Developed and maintained backend utilities, API integrations, Servlets and server-side validations using Enterprise Java (Jakarta EE); contributed to front-end validations using JavaScript and ensured seamless functionality across modules."
             ]
@@ -13,7 +23,9 @@
         {
             "title": "Software Engineer Trainee",
             "company": "Newgen Software Technologies Limited",
+            "companyUrl": "https://newgensoft.com",
             "duration": "Feb 2025 - Jun 2025",
+            "tags": ["Java", "JavaScript", "Web Applications"],
             "description": [
                 "Collaborated with cross-functional teams to develop and maintain web applications."
             ]

--- a/data.json
+++ b/data.json
@@ -1,4 +1,22 @@
 {
-    "about_text": "An enthusiastic beginner in the programming world. Love to code and learn different technologies. Looking forward to gain experience in real life projects.",
-    "email": "shivamv1332@gmail.com"
+    "about_text": "Software Engineer with 1+ year of experience in full-stack development and API design. Passionate about solving complex problems and building technology that delivers measurable value. Expertise in Java, JavaScript, Golang and frameworks like React.js and Next.js.",
+    "email": "shivamv1332@gmail.com",
+    "experience": [
+        {
+            "title": "Software Engineer",
+            "company": "Newgen Software Technologies Limited",
+            "duration": "Jul 2025 - Present",
+            "description": [
+                "Developed and maintained backend utilities, API integrations, Servlets and server-side validations using Enterprise Java (Jakarta EE); contributed to front-end validations using JavaScript and ensured seamless functionality across modules."
+            ]
+        },
+        {
+            "title": "Software Engineer Trainee",
+            "company": "Newgen Software Technologies Limited",
+            "duration": "Feb 2025 - Jun 2025",
+            "description": [
+                "Collaborated with cross-functional teams to develop and maintain web applications."
+            ]
+        }
+    ]
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -121,6 +121,10 @@
   scrollbar-width: none;
 } */
 
+html {
+  scroll-behavior: smooth;
+}
+
 html::-webkit-scrollbar{
   display:none;
 }


### PR DESCRIPTION
### Overview

A comprehensive overhaul of the portfolio site covering security hardening, accessibility, SEO, code quality cleanup, and a full round of engagement-focused UI/UX improvements across every section.

---

### Changes by Category

#### Security & Code Quality
- Added `rel="noopener noreferrer"` to all external `<a>` tags
- Removed unused font imports (`Raleway`, `Space_Grotesk`) from `layout.jsx`
- Replaced `SmoothLink` (client component) in server component `Home.jsx` with plain `<a>` tags + CSS `scroll-behavior: smooth`
- Extracted `fetchRepos()` into a named function for retry support; added `res.ok` HTTP status check and missing-data guard in `Projects.jsx`

#### Accessibility
- Added `aria-label` to all icon-only links and buttons across `Navbar.jsx`, `SocialLinks.jsx`, `Projects.jsx`
- Added `aria-label="main content"` to the `<main>` element in `layout.jsx`

#### SEO & Metadata
- Added OpenGraph and Twitter Card metadata to layout.jsx
- Updated page `<title>` and `<meta name="description">`

#### Navbar
- Replaced plain "Shivam" text with a SVG monogram logo
- Added `IntersectionObserver`-based active section highlight on nav links

#### Home
- Animated "Open to work" badge.

#### About
- Added `// About me` section heading
- Skills grid driven from data.json `skills` array (4 categories)
- Fixed `Skill` component: removed hardcoded `text-[36px]`, now inherits parent font size

#### Experience
- Added `// Experience` section heading
- Company favicon via Google Favicon API
- Company name now links to `companyUrl` (from data.json)
- Tech tag pills per role driven from `tags` array in data.json
- Duration displayed on the right side of the card header

#### Projects
- Added `// Projects` section heading
- Star count badge on each repo card
- "Live" and "Code" CTA buttons per card (from `homepageUrl` and repo URL)
- Improved error state with retry button and descriptive error message

#### Contact
- Added `// Contact` section heading
- LinkedIn CTA button driven from data.json `linkedinUrl`
- "Typically responds within 24 hours" supporting copy

#### Data & API
- data.json: added `about_text`, `email`, `linkedinUrl`, `openToWork`, `skills[]`, and `companyUrl`/`tags` per experience entry
- route.js: GraphQL query now fetches `stargazerCount` and `homepageUrl`
- globals.css: added `html { scroll-behavior: smooth; }`

#### Documentation
- Rewrote README.md with tech stack table, features list, project structure, getting started steps, content update guide, and deployment notes